### PR TITLE
change name is setup.py from pytorch_fnet to fnet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
             'fnet = fnet.cli.main:main',
         ]
     },
-    name='pytorch_fnet',
+    name='fnet',
     packages=setuptools.find_packages(),
     python_requires='>=3.6',
     url='https://github.com/AllenCellModeling/pytorch_fnet',


### PR DESCRIPTION
the name variable is supposed to be the python package name (afaik???) this is what i'm going off of: https://packaging.python.org/tutorials/packaging-projects/

anyway the name mismatch was breaking the ability to have something like `fnet@git+https://github.com/AllenCellModeling/pytorch_fnet@BUGFIX/setup_name#egg=fnet` in the setup.py of my own package... i'd get an error about metadata missing and can't find the pytorch_fnet directory etc.  this seems to fix things up.