### PR TITLE
fix inconsistency in multi-channel network

### DIFF
--- a/fnet/nn_modules/fnet_nn_3d_params.py
+++ b/fnet/nn_modules/fnet_nn_3d_params.py
@@ -15,7 +15,7 @@ class Net(torch.nn.Module):
         self.out_channels = out_channels
         
         self.net_recurse = _Net_recurse(n_in_channels=self.in_channels, mult_chan=self.mult_chan, depth=self.depth)
-        self.conv_out = torch.nn.Conv3d(self.mult_chan, self.out_channels, kernel_size=3, padding=1)
+        self.conv_out = torch.nn.Conv3d(self.in_channels*self.mult_chan, self.out_channels, kernel_size=3, padding=1)
 
     def forward(self, x):
         x_rec = self.net_recurse(x)


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request: _bug-fix/dimension-fix-for-multi-channel_. 
- [x] Link to any relevant issue in the PR description: _seems to be relevant to #112_
- [x] Provide context of changes.
    I want to train this network over some multi-channel single layer images (shape = [chan, row, col]), so I just copied `fnet/nn_modules/fnet_nn_3d_params.py` and changed all the 3d functions to 2d. However, some errors showed up. I walked around them with some nasty modifications, and this is the only one that is a must-fix. 
    I do not include other mods because they may not obey your conventions of image shape, and I am not confident with my programming skill and style. Things I am not comfortable with include:
    + `fnet/data/tiffdataset.py` assumes the channel to be one when unsqueezing the images
    + `fnet/data/bufferedpatchdataset.py` assumes the signal and target images have the same number of channels.
- [] Provide relevant tests for your feature or bug fix.
    As the context part said, my own images are 2 dimensional, so I do not have direct tests for this. But after the same fix the network works out fine on 2d.
- [ ] Provide or update documentation for any feature added by your pull request.

